### PR TITLE
Fix problem with identifying property keys that prevents remote grids…

### DIFF
--- a/src/main/resources/archetype-resources/src/test/java/SuiteConfiguration.java
+++ b/src/main/resources/archetype-resources/src/test/java/SuiteConfiguration.java
@@ -51,7 +51,7 @@ public class SuiteConfiguration {
   }
 
   public boolean hasProperty(String name) {
-    return properties.contains(name);
+    return properties.containsKey(name);
   }
 
   public String getProperty(String name) {


### PR DESCRIPTION
… from being used when configured

Fixes issue #2 

Changes the method used to determine whether a property value has been set by looking by name, rather than by value.