### PR TITLE
hasproperty should use containsKey(keyname)

### DIFF
--- a/src/main/resources/archetype-resources/src/test/java/SuiteConfiguration.java
+++ b/src/main/resources/archetype-resources/src/test/java/SuiteConfiguration.java
@@ -51,7 +51,7 @@ public class SuiteConfiguration {
   }
 
   public boolean hasProperty(String name) {
-    return properties.contains(name);
+    return properties.containsKey(name);
   }
 
   public String getProperty(String name) {


### PR DESCRIPTION
hasProperty return always false , should use containsKey()